### PR TITLE
Changed field type to text in the rules element.

### DIFF
--- a/config/install/field.field.paragraph.rac_element.field_value.yml
+++ b/config/install/field.field.paragraph.rac_element.field_value.yml
@@ -13,11 +13,7 @@ label: Value
 description: ''
 required: true
 translatable: false
-default_value:
-  -
-    value: 0
+default_value: {  }
 default_value_callback: ''
-settings:
-  on_label: 'True'
-  off_label: 'False'
-field_type: boolean
+settings: {  }
+field_type: string

--- a/config/install/field.storage.paragraph.field_value.yml
+++ b/config/install/field.storage.paragraph.field_value.yml
@@ -7,8 +7,11 @@ dependencies:
 id: paragraph.field_value
 field_name: field_value
 entity_type: paragraph
-type: boolean
-settings: {  }
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1


### PR DESCRIPTION
Earlier the return values from OpenFisca were only boolean. 
This change allows the return values to be anything - hence making things more generic. 

Before
![Screenshot 2024-03-14 at 2 36 18 PM](https://github.com/salsadigitalauorg/webform_openfisca/assets/120015/1cfb5a4d-8669-411e-8d0f-280ab748d4f6)

After
![Screenshot 2024-03-14 at 2 36 01 PM](https://github.com/salsadigitalauorg/webform_openfisca/assets/120015/abe5e6a2-0ca6-4a5f-92de-4ce5ee68f2f9)
